### PR TITLE
Fix CI: install system deps for cdl-slides

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpango1.0-dev libcairo2-dev ffmpeg
+
       - name: Install dependencies
         run: |
           pip install cdl-slides pyyaml playwright


### PR DESCRIPTION
## Summary

- Install `libpango1.0-dev`, `libcairo2-dev`, and `ffmpeg` system packages before `pip install cdl-slides`
- Fixes the deploy workflow failure where `manimpango` couldn't build without `pangocairo`

## Context

The initial deploy after merging #279 failed because `cdl-slides` depends on `manim` → `manimpango`, which requires Pango/Cairo C libraries that aren't pre-installed on Ubuntu GitHub Actions runners.

## Test plan

- [ ] GitHub Actions workflow completes successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)